### PR TITLE
Added note about EMS bridges

### DIFF
--- a/src/integrations/morg-Slack-Bridge.md
+++ b/src/integrations/morg-Slack-Bridge.md
@@ -30,6 +30,7 @@ An EMS server is not required.
 ![temp](/images/Screen%20Shot%202020-10-27%20at%2011.15.37%20AM.png)
 
 1. Click `Add Bridge`  
+**NOTE if you have purchased your Slack bridge from EMS:** Ensure it says `Slack integration on <your ems domain>` here.  
 ![temp](/images/Screen%20Shot%202020-10-27%20at%2011.16.21%20AM.png)
 
 1. Click `Add to Slack`  


### PR DESCRIPTION
On the "Add integrations" step, you must ensure you connect to the correct bridge if you have purchased the Slack bridge from EMS. We have a customer who accidentally connected to the free matrix.org one, and this is causing issues.