### PR TITLE
Adding a list of hostnames that a customer should be able to access

### DIFF
--- a/ee-installer/src/install-poc.md
+++ b/ee-installer/src/install-poc.md
@@ -164,7 +164,6 @@ Further, you need to make sure that your host is able to access the following ho
 - gitlab.matrix.org
 - pypi.org
 
-
 Further, you will also need to make sure that your host can access your distributions' package repositories. As these hostnames can vary, it is beyond the scope of this documentation to enumerate them.
 
 ### Users

--- a/ee-installer/src/install-poc.md
+++ b/ee-installer/src/install-poc.md
@@ -23,7 +23,7 @@ to be considered and this guide will work through them:
 - [Machine Size](install-poc.md#machine-size)
 - [Operating System](install-poc.md#operating-system)
 - [Users](install-poc.md#users)
-- [Network Ports to Open](install-poc.md#network-ports-to-open)
+- [Network Specifics](install-poc.md#network-specifics)
 - [Postgresql Database](install-poc.md#postgresql-database)
 - [TURN Server](install-poc.md#turn-server)
 - [SSL Certificates](install-poc.md#ssl-certificates)
@@ -140,7 +140,7 @@ EL: (as a normal user)
 pip3 install signedjson --user
 ```
 
-### Network Ports to Open
+### Network Specifics
 
 Element Enterprise On-Premise needs to bind and serve content over:
 
@@ -157,6 +157,16 @@ For EL, you need to disable the firewall with these command:
 sudo systemctl stop firewalld
 sudo systemctl disable firewalld
 ```
+
+Further, you need to make sure that your host is able to access the following hosts on the internet:
+
+```
+api.snapcraft.io
+gitlab.matrix.org
+pypi.org
+```
+
+Further, you will also need to make sure that your host can access your distributions' package repositories. As these hostnames can vary, it is beyond the scope of this documentation to enumerate them.
 
 ### Users
 
@@ -481,7 +491,7 @@ Let’s review! Have you considered:
 - [Hostnames/DNS](install-poc.md#hostnamesdns)
 - [Operating System](install-poc.md#operating-system)
 - [Users](install-poc.md#users)
-- [Network Ports to Open](install-poc.md#network-ports-to-open)
+- [Network Specifics](install-poc.md#network-specifics)
 - [Postgresql Database](install-poc.md#postgresql-database)
 - [TURN Server](install-poc.md#turn-server)
 - [SSL Certificates](install-poc.md#ssl-certificates)

--- a/ee-installer/src/install-poc.md
+++ b/ee-installer/src/install-poc.md
@@ -160,11 +160,10 @@ sudo systemctl disable firewalld
 
 Further, you need to make sure that your host is able to access the following hosts on the internet:
 
-```
-api.snapcraft.io
-gitlab.matrix.org
-pypi.org
-```
+- api.snapcraft.io
+- gitlab.matrix.org
+- pypi.org
+
 
 Further, you will also need to make sure that your host can access your distributions' package repositories. As these hostnames can vary, it is beyond the scope of this documentation to enumerate them.
 

--- a/ee-installer/src/install-poc.md
+++ b/ee-installer/src/install-poc.md
@@ -163,6 +163,8 @@ Further, you need to make sure that your host is able to access the following ho
 - api.snapcraft.io
 - gitlab.matrix.org
 - pypi.org
+- docker.io
+- *.docker.com
 
 Further, you will also need to make sure that your host can access your distributions' package repositories. As these hostnames can vary, it is beyond the scope of this documentation to enumerate them.
 


### PR DESCRIPTION
These commits add a list of hostnames to the PoC documentation so that customers in secure environments know which hosts they need to be able to communicate with.