### PR TITLE
mdbook to Bookstack conversion scripts

### DIFF
--- a/bookstack.py
+++ b/bookstack.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+
+# An API Wrapper Library for boostack.
+
+# Copyright 2022 GNU Public License v2
+
+import subprocess,json,urllib.parse
+
+class bookstack_api(object):
+	tokenid=""
+	tokensecret=""
+	bookstack_host=""
+	protocol="https"
+	port=80
+	def __init__(self,myhost="localhost",mytokenid="",mytokensecret=""):
+		self.tokenid=mytokenid
+		self.tokensecret=mytokensecret
+		self.bookstack_host=myhost
+	def set_token(self,mytokenid,mytokensecret):
+		self.tokenid=mytokenid
+		self.tokensecret=mytokensecret
+	def get_token(self):
+		return self.token+":"+self.tokensecret
+	def set_bookstack_host(self,myhost):
+		self.bookstack_host=myhost
+	def get_bookstack_host(self):
+		return self.bookstack_host
+	def set_protocol(self,myprotocol):
+		self.protocol=myprotocol
+	def get_protocol(self):
+		return self.protocol
+	def set_port(self,myport):
+		self.port=myport
+	def get_port(self):
+		return self.port
+	def call_get_api(self,apicall):
+		return json.loads((subprocess.getoutput("curl -sk --request GET --url "+self.protocol+"://"+self.bookstack_host+":"+str(self.port)+"/api/"+apicall+" --header 'Authorization: Token "+self.tokenid+":"+self.tokensecret+"'")))
+	def call_post_api(self,apicall,parameters):
+		curlcommand="curl -sk --request POST --url '"+self.protocol+"://"+self.bookstack_host+":"+str(self.port)+"/api/"+apicall+"?"
+		for param in parameters:
+			#print(param)
+			curlcommand=curlcommand+urllib.parse.quote(param)+"="+urllib.parse.quote(parameters[param])+"&"
+		curlcommand=curlcommand.rstrip("&")+"'"
+		curlcommand=curlcommand+" --header 'Authorization: Token "+self.tokenid+":"+self.tokensecret+"'"
+		#print(curlcommand)
+		x=subprocess.getoutput(curlcommand)
+		#print(x)
+		try:
+			return json.loads(x)
+		except:
+			return "Too big"
+	def call_post_json_api(self,apicall,jsonfile):
+		#return json.loads(subprocess.getoutput
+		print("curl -sk --request POST --url '"+self.protocol+"://"+self.bookstack_host+":"+str(self.port)+"/api/"+apicall+"' -H 'Content-Type:application/json' --data "+'"$(cat '+jsonfile+')"'+" --header 'Authorization: Token "+self.tokenid+":"+self.tokensecret+"'")
+
+

--- a/ee-installer/src/install-poc.md
+++ b/ee-installer/src/install-poc.md
@@ -161,6 +161,7 @@ sudo systemctl disable firewalld
 Further, you need to make sure that your host is able to access the following hosts on the internet:
 
 - api.snapcraft.io
+- *.snapcraftcontent.com
 - gitlab.matrix.org
 - pypi.org
 - docker.io

--- a/mdbook-to-bookstack.py
+++ b/mdbook-to-bookstack.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+
+from bookstack import bookstack_api
+import os,sys
+
+# Copyright 2022 GNU Public License v2
+
+
+# Variables for your bookstack install and api
+
+bookstack_protocol="http"
+bookstack_host="localhost"
+bookstack_port="6875"
+bookstack_api_secret_id="CsUQGvtnve8hzXOsuKBCAGXhhku7bwyO"
+bookstack_api_secret="nqPjmsWipgiLEYBkBh18WodkCtLXtI7b"
+
+
+# Establish a bookstack connection
+
+bs=bookstack_api(bookstack_host,bookstack_api_secret_id,bookstack_api_secret)
+bs.set_protocol(bookstack_protocol)
+bs.set_port(bookstack_port)
+
+
+# Read the book.toml of the mdbook
+pars={}
+f=open("book.toml")
+for line in f:
+	line=line.strip("\n")
+	line=line.split("=")
+	if "title" in line[0].lower():
+		pars["name"]=line[1].rstrip('"').lstrip(' "')
+	if "description" in line[0].lower():
+		pars["description"]=line[1].rstrip('"').lstrip(' "')
+	if "src" in line[0].lower():
+		try:
+			filepath=line[1].rstrip('"').lstrip(' "')
+		except:
+			pass
+
+f.close()
+
+# Create the bookstack book.
+
+print("Creating a book named: '"+pars["name"]+"' in Bookstack....")
+
+newbook=bs.call_post_api("books",pars)
+book_id=str(newbook["id"])
+book_slug=str(newbook["slug"])
+chapter_id=None
+failed={}
+
+# Read the SUMMARY.md file to determine chapter / page layout and import pages into Bookstack
+
+f=open(filepath+"/SUMMARY.md")
+for line in f:
+	line=line.strip("\n")
+	if "-" in line and ".md" in line.lower():
+		# We have a link to a page that we need to go get and recreate in Bookstack.
+		page_title=line.split("[")[1].split("]")[0]
+		page_file=filepath+"/"+line.split("(")[1].split(")")[0]	
+		pars={}
+		pars["book_id"]=book_id
+		if not chapter_id==None:
+			pars["chapter_id"]=chapter_id
+		pars["name"]=page_title
+		pf=open(page_file)
+		linecount=0
+		# This moves the file past the first line before reading so that we don't have duplicate titles.
+		for pfline in pf:
+			if linecount>0:
+				pars["markdown"]=pf.read()
+			linecount=linecount+1
+		# fix images
+		images=[]
+		# Need to parse the markdown to put a proper image url in place.
+		for mdline in pars["markdown"].split("\n"):
+			if "![" in mdline:
+				image_name=mdline.split("(")[1].split(")")[0]
+				# Don't replace the image_name more than once.
+				if not image_name in images:
+					pars["markdown"]=pars["markdown"].replace(image_name,"https://ems-docs.element.io/"+image_name)
+					images.append(image_name)
+		pf.close()
+		if bs.call_post_api("pages",pars)=="Too big":
+			# Append this file to the failure list, but go ahead and put a stub in bookstack.
+			pars["markdown"]="Need to fill this in later. The markdown in file "+page_file+" was deemed too large to import via the Bookstack API."
+			pagestub=bs.call_post_api("pages",pars)
+			failed[page_file]=pagestub["slug"]
+	elif "-" in line:
+		# These were section headers in the SUMMARY.md and don't have an equivalent in bookstack.
+		pass
+		#print("Ignore these lines")
+	else:
+		# We have the start of a chapter and need to create it in bookstack.
+		chapter_name=line.lstrip("# ")
+		if not len(chapter_name)==0:
+			pars={}
+			pars["book_id"]=str(book_id)
+			pars["name"]=chapter_name
+			newchapter=bs.call_post_api("chapters",pars)
+			chapter_id=str(newchapter["id"])
+
+f.close()
+print()
+print("The following files failed to automatically convert via the API due to being too large:")
+print
+for fail in failed:
+	print(fail)
+	print("   - Edit at: "+bookstack_protocol+"://"+bookstack_host+":"+bookstack_port+"/books/"+book_slug+"/page/"+failed[fail])

--- a/mdbook-to-bookstack.py
+++ b/mdbook-to-bookstack.py
@@ -9,10 +9,10 @@ import os,sys
 # Variables for your bookstack install and api
 
 bookstack_protocol="http"
-bookstack_host="localhost"
-bookstack_port="6875"
-bookstack_api_secret_id="CsUQGvtnve8hzXOsuKBCAGXhhku7bwyO"
-bookstack_api_secret="nqPjmsWipgiLEYBkBh18WodkCtLXtI7b"
+bookstack_host="hostname"
+bookstack_port="port"
+bookstack_api_secret_id="api-secret-id"
+bookstack_api_secret="api-secret"
 
 
 # Establish a bookstack connection


### PR DESCRIPTION
I know we don't have a ready to go bookstack instance just yet, but using my testing instance, I've been able to put together a script that takes an existing mdbook and converts it to a bookstack book.

There are two files here -- one is bookstack.py and that is a python library wrapper around the bookstack api. 

The other file is mdbook-to-bookstack.py and it does the work of reading the book.toml and the SUMMARY.md and then recreating the book in bookstack using the API. 