### PR TITLE
Adding documentation on pointing the installer at an existing Jitsi

### DIFF
--- a/ee-installer/src/SUMMARY.md
+++ b/ee-installer/src/SUMMARY.md
@@ -5,6 +5,7 @@
 - [How to Install a POC Environment](./install-poc.md)
 - [How to Install a Production Environment](./install-prod.md)
 - [Setting up Permalinks](./permalinks.md)
+- [Setting up Jitsi](./jitsi.md)
 - [Setting up SSO/SAML](./saml.md)
 - [Setting up Group Sync](./groupsync.md)
 - [Setting Up the Integration Manager](./dimension.md)

--- a/ee-installer/src/jitsi.md
+++ b/ee-installer/src/jitsi.md
@@ -1,0 +1,20 @@
+# Configuring Jitsi
+
+By default, our installer will give you an instance of element-web configured to use the `meet.element.io` Jitsi server. If you would like to specify your own Jitsi server for your element-web instance to use, please follow these directions.
+
+## On Element
+
+- Create a file called `jitsi.json` in the `extra-config/element` directory.
+- Edit the file :
+
+```lang-none
+{
+      "jitsi": {
+            "preferredDomain": "your.jitsi.example.org"
+      }
+}
+```
+
+replacing `your.jitsi.example.org` with the hostname of your Jitsi server.
+
+- Restart the install script

--- a/ee-installer/src/jitsi.md
+++ b/ee-installer/src/jitsi.md
@@ -2,7 +2,7 @@
 
 By default, our installer will give you an instance of element-web configured to use the `meet.element.io` Jitsi server. If you would like to specify your own Jitsi server for your element-web instance to use, please follow these directions.
 
-## On Element
+## Element Extra Configurations
 
 - Create a file called `jitsi.json` in the `extra-config/element` directory.
 - Edit the file :

--- a/ee-installer/src/permalinks.md
+++ b/ee-installer/src/permalinks.md
@@ -1,6 +1,6 @@
 # Configuring Permalinks
 
-## On Element
+## Element Extra Configurations
 
 - Copy sample file from `config-sample/element/permalinks.json` to
 `extra-config/element`


### PR DESCRIPTION
This documentation informs customers how to use an existing Jitsi other than meet.element.io. As such, this will close https://gitlab.matrix.org/new-vector/modular/on-premise-synapse/-/issues/26